### PR TITLE
Removed container name for slaves. 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,6 @@ services:
     ports:
       - "9864"
       - "8042"
-    container_name: "slave"
   zoo1:
     image: zookeeper:3.4
     restart: always


### PR DESCRIPTION
Specifying the container name leads to a failure when spinning up more than one slave due to the name clash. Having more than one slave container didn't work in that case.