### PR TITLE
Made docker-compose up run as a daemon.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ hadoop-base/hadoop-${HADOOP_VERSION}.tar.gz:
 	mv hadoop-${HADOOP_VERSION}.tar.gz hadoop-base/
 
 up:
-	docker-compose up --scale slave=${SCALE}
+	docker-compose up -d --scale slave=${SCALE}
 	echo "http://localhost:9870 for HDFS"
 	echo "http://localhost:8088 for YARN"
 


### PR DESCRIPTION
For it to return and to actually return the echo statements of the `up` target. I'm not 100% sure whether we want to have that. Alternatively, we could remove the echo statements from the `up` target as we wouldn't see them at all in case of `docker-compose up` not running as a daemon process.

I couldn't verify the URL's, though.